### PR TITLE
Fix OSLogStore compile error with correct enumerator selector

### DIFF
--- a/Sources/ObjCSources/GleapConsoleLogHelper.m
+++ b/Sources/ObjCSources/GleapConsoleLogHelper.m
@@ -55,7 +55,7 @@ static NSTimeInterval const kGleapOSLogMaxWallClock = 0.2;
             OSLogPosition *position = [store positionWithDate:self.sessionStartDate];
             NSPredicate *predicate = [NSPredicate predicateWithFormat:
                 @"(subsystem == NULL) OR NOT (subsystem BEGINSWITH 'com.apple.')"];
-            OSLogEnumerator *enumerator = [store reverseEnumeratorWithOptions:0
+            OSLogEnumerator *enumerator = [store entriesEnumeratorWithOptions:OSLogEnumeratorReverse
                                                                      position:position
                                                                     predicate:predicate
                                                                         error:&error];
@@ -70,11 +70,8 @@ static NSTimeInterval const kGleapOSLogMaxWallClock = 0.2;
                 NSString *message = logEntry.composedMessage;
                 if (!message || message.length == 0) { continue; }
 
-                NSString *priority = @"INFO";
-                if (logEntry.level == OSLogEntryLogLevelError ||
-                    logEntry.level == OSLogEntryLogLevelFault) {
-                    priority = @"ERROR";
-                }
+                NSString *priority = (logEntry.level == OSLogEntryLogLevelError ||
+                                      logEntry.level == OSLogEntryLogLevelFault) ? @"ERROR" : @"INFO";
                 if (message.length > 1000) {
                     message = [[message substringToIndex:1000] stringByAppendingString:@" [truncated]"];
                 }


### PR DESCRIPTION
## Summary
- Switches from the non-existent `reverseEnumeratorWithOptions:position:predicate:error:` selector to the documented `entriesEnumeratorWithOptions:position:predicate:error:`, passing `OSLogEnumeratorReverse` in the options bitmask.
- Fixes the build error: *No visible @interface for 'OSLogStore' declares the selector 'reverseEnumeratorWithOptions:position:predicate:error:'*.
- No behavior change otherwise: still reverse-enumerates from `sessionStartDate`, still caps at `kGleapOSLogMaxEntries` (300), still honors the `kGleapOSLogMaxWallClock` (0.2s) safety cap, still reverses collected entries for chronological output.

## Why
The previous optimization commit (`66206f7`) introduced a selector that doesn't exist on `OSLogStore`. The correct Objective-C API for reverse enumeration is `entriesEnumeratorWithOptions:` with the `OSLogEnumeratorReverse` flag.

## Test plan
- [x] Builds clean against \`iphonesimulator\` SDK (\`xcodebuild -scheme Gleap -sdk iphonesimulator build\` → \`** BUILD SUCCEEDED **\`)
- [ ] Smoke test in a host app on iOS 15+: emit several \`os_log\` entries, trigger feedback submission, confirm \`consoleLog\` in the payload is populated and the submit UI does not freeze
- [ ] iOS 14 regression check: STDERR/STDOUT pipe fallback still works (deployment target unchanged at iOS 12 per \`Package.swift\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)