### PR TITLE
fix(141630): recover session on widget open after offline app launch

### DIFF
--- a/Gleap.podspec
+++ b/Gleap.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Gleap"
-  s.version      = "15.4.0"
+  s.version      = "16.4.0"
   s.summary      = "In-App Bug Reporting and Testing for Apps. Learn more at https://gleap.io"
   s.homepage     = "https://gleap.io"
   s.license      = { :type => 'Commercial', :file => 'LICENSE.md' }

--- a/Sources/ObjCSources/GleapCore.m
+++ b/Sources/ObjCSources/GleapCore.m
@@ -548,13 +548,14 @@ static id ObjectOrNull(id object)
  Starts the bug reporting flow, when a SDK key has been assigned.
  */
 - (Boolean)startFeedbackFlow:(NSString * _Nullable)feedbackFlow withOptions:(NSDictionary * _Nullable)options {
-    if (GleapSessionHelper.sharedInstance.currentSession == nil) {
-        NSLog(@"[GLEAP_SDK] Gleap session not ready.");
-        return NO;
-    }
-    
     if (Gleap.sharedInstance.token == nil || Gleap.sharedInstance.token.length == 0) {
         NSLog(@"[GLEAP_SDK] Please provide a valid Gleap project TOKEN!");
+        return NO;
+    }
+
+    if (GleapSessionHelper.sharedInstance.currentSession == nil) {
+        NSLog(@"[GLEAP_SDK] Gleap session not ready.");
+        [self recoverSessionAndRestartFlow: feedbackFlow withOptions: options];
         return NO;
     }
     
@@ -595,6 +596,46 @@ static id ObjectOrNull(id object)
     }
     
     return YES;
+}
+
+/**
+ Attempts to restart the Gleap session when the widget is opened without one (e.g. the app was launched offline).
+ On success the widget opens as requested; on failure the user gets the same offline alert the widget shows when it fails to load.
+ */
+- (void)recoverSessionAndRestartFlow:(NSString * _Nullable)feedbackFlow withOptions:(NSDictionary * _Nullable)options {
+    // Surveys are triggered programmatically — keep failing silently for them.
+    bool isSurvey = options != nil && [options objectForKey: @"isSurvey"] != nil && [[options objectForKey: @"isSurvey"] boolValue];
+    if (isSurvey) {
+        return;
+    }
+
+    static BOOL sessionRecoveryInProgress = NO;
+    if (sessionRecoveryInProgress) {
+        return;
+    }
+    sessionRecoveryInProgress = YES;
+
+    [[GleapSessionHelper sharedInstance] startSessionWith:^(bool success) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            sessionRecoveryInProgress = NO;
+            if (success) {
+                [[GleapConfigHelper sharedInstance] run];
+                [self startFeedbackFlow: feedbackFlow withOptions: options];
+            } else {
+                NSError *offlineError = [NSError errorWithDomain: NSURLErrorDomain code: NSURLErrorNotConnectedToInternet userInfo: nil];
+                UIAlertController *alertController = [UIAlertController alertControllerWithTitle: offlineError.localizedDescription
+                                                                                         message: nil
+                                                                                  preferredStyle: UIAlertControllerStyleAlert];
+                [alertController addAction: [UIAlertAction actionWithTitle: @"OK"
+                                                                     style: UIAlertActionStyleCancel
+                                                                   handler: nil]];
+                UIViewController *topMostViewController = [GleapUIHelper getTopMostViewController];
+                if (topMostViewController != nil) {
+                    [topMostViewController presentViewController: alertController animated: YES completion:^{}];
+                }
+            }
+        });
+    }];
 }
 
 /*

--- a/Sources/ObjCSources/GleapMetaDataHelper.h
+++ b/Sources/ObjCSources/GleapMetaDataHelper.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#define SDK_VERSION @"15.4.0"
+#define SDK_VERSION @"16.4.0"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## Problem
Reported in Gleap ticket #141630 (Leica FOTOS): when the app is launched **without** an internet connection, tapping any Gleap entry point (Customer support, Feature request, …) does nothing at all. If connectivity is lost only **after** launch, the widget correctly shows the system offline alert ("The internet connection appears to be offline.").

## Root cause
`initializeWithToken` starts the session exactly once. If that POST fails (device offline at launch), `currentSession` stays `nil` forever — there is no retry. Every `open*` API funnels into `startFeedbackFlow:withOptions:`, which silently returns `NO` when `currentSession == nil` (only an `NSLog`).

## Fix
When an explicit (non-survey) open happens without a session, retry the session start on the spot:
- **Success** (connectivity restored since launch): run `GleapConfigHelper` and open the widget as requested — the SDK self-heals.
- **Failure** (still offline): present the same system-localized offline alert (`NSURLErrorNotConnectedToInternet`) the widget shows in the mid-session case, so the user always gets feedback.

Programmatically triggered surveys keep failing silently, and a re-entrancy guard prevents duplicate recovery attempts/alerts.

## Verification
`xcodebuild -scheme Gleap -destination 'generic/platform=iOS Simulator' build` → BUILD SUCCEEDED.

## Note
The Android SDK has the identical silent no-op (`Gleap.open()` gates on `isSessionLoaded()` with no retry) — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)