### PR TITLE
Answer collect-ticket-data under a deadline (Gleap #137095)

### DIFF
--- a/Sources/ObjCSources/GleapFeedback.h
+++ b/Sources/ObjCSources/GleapFeedback.h
@@ -19,7 +19,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)prepareData;
 - (void)prepareMainThreadData;
 - (void)prepareBackgroundData;
-- (void)prepareDataAsyncWithCompletion:(void (^)(void))completion;
+
+/**
+ Collects the report and calls `completion` on the main thread as soon as it is
+ ready, or after `deadline` seconds — whichever comes first. Must be called from
+ the main thread.
+
+ Console logs are the only slow part (OSLogStore can block for well over a
+ second on a real device); everything else is in-memory and is always present by
+ the time `completion` runs. When the logs miss the deadline they are simply left
+ out. Use this whenever a late reply costs more than missing console logs — the
+ widget, for one, discards the entire payload if the reply arrives too late.
+ */
+- (void)prepareDataWithDeadline:(NSTimeInterval)deadline completion:(void (^)(void))completion;
 
 @property (nonatomic, retain) NSDictionary* excludeData;
 @property (nonatomic, retain) NSMutableDictionary* data;

--- a/Sources/ObjCSources/GleapFeedback.m
+++ b/Sources/ObjCSources/GleapFeedback.m
@@ -151,18 +151,32 @@
     [self attachData: @{ @"metaData": [[GleapMetaDataHelper sharedInstance] getMetaData] }];
 }
 
+/*
+ Builds the merged console log without touching self.data, so it can be collected
+ off the main thread while the rest of the report is already assembled.
+ */
+- (NSArray *)collectConsoleLog {
+    NSMutableArray *consoleLogs = [[NSMutableArray alloc] initWithArray: [[GleapConsoleLogHelper sharedInstance] getConsoleLogs]];
+    NSArray *existingConsoleLogs = [[GleapExternalDataHelper sharedInstance].data objectForKey: @"consoleLog"];
+    if (existingConsoleLogs != nil && existingConsoleLogs.count > 0) {
+        [consoleLogs addObjectsFromArray: existingConsoleLogs];
+    }
+    return consoleLogs;
+}
+
 - (void)prepareBackgroundData {
     // Attach and merge console log. getConsoleLogs can block for hundreds of ms
     // on iOS 15+ while OSLogStore builds its enumerator — hence this half runs off main.
-    NSMutableArray *consoleLogs = [[NSMutableArray alloc] initWithArray: [[GleapConsoleLogHelper sharedInstance] getConsoleLogs]];
-    if ([[GleapExternalDataHelper sharedInstance].data objectForKey: @"consoleLog"] != nil) {
-        NSArray *existingConsoleLogs = [[GleapExternalDataHelper sharedInstance].data objectForKey: @"consoleLog"];
-        if (existingConsoleLogs != nil && existingConsoleLogs.count > 0) {
-            [consoleLogs addObjectsFromArray: existingConsoleLogs];
-        }
-    }
-    [self attachData: @{ @"consoleLog": consoleLogs }];
+    [self attachData: @{ @"consoleLog": [self collectConsoleLog] }];
 
+    [self prepareInMemoryData];
+}
+
+/*
+ Everything except the console log. All of it is read from in-memory state and
+ returns immediately.
+ */
+- (void)prepareInMemoryData {
     // Attach custom data.
     [self attachData: @{ @"customData": [GleapCustomDataHelper getCustomData] }];
 
@@ -216,13 +230,37 @@
     [self prepareBackgroundData];
 }
 
-- (void)prepareDataAsyncWithCompletion:(void (^)(void))completion {
+- (void)prepareDataWithDeadline:(NSTimeInterval)deadline completion:(void (^)(void))completion {
+    // Must be called from the main thread — prepareMainThreadData reads UIKit.
+    // Everything but the console log is in-memory and returns right away, so the
+    // report is already complete except for the logs by the time we get here.
     [self prepareMainThreadData];
+    [self prepareInMemoryData];
+
+    __block BOOL finished = NO;
+    // Only ever invoked on the main queue, so `finished` and self.data stay
+    // serialised against the collection running on the background queue.
+    void (^finish)(NSArray * _Nullable) = ^(NSArray * _Nullable consoleLog) {
+        if (finished) { return; }
+        finished = YES;
+
+        if (consoleLog != nil) {
+            [self attachData: @{ @"consoleLog": consoleLog }];
+            [self excludeExcludedData];
+        }
+
+        if (completion) { completion(); }
+    };
+
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-        [self prepareBackgroundData];
+        NSArray *consoleLog = [self collectConsoleLog];
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (completion) { completion(); }
+            finish(consoleLog);
         });
+    });
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(deadline * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        finish(nil);
     });
 }
 

--- a/Sources/ObjCSources/GleapFrameManagerViewController.m
+++ b/Sources/ObjCSources/GleapFrameManagerViewController.m
@@ -22,6 +22,12 @@
 #import "GleapPreFillHelper.h"
 #import "GleapAgentToolHelper.h"
 
+// How long we may take to answer the widget's `collect-ticket-data` request.
+// The widget drops the whole payload once its own timeout elapses, so this stays
+// comfortably below it (see CommunicationManager.sendMessageWithResolver in the
+// messenger).
+static NSTimeInterval const kGleapCollectTicketDataDeadline = 0.4;
+
 @interface GleapFrameManagerViewController ()
 
 @property (retain, nonatomic) WKWebView *webView;
@@ -678,12 +684,16 @@ static id ObjectOrNull(id object)
         }
         
         if ([name isEqualToString: @"collect-ticket-data"]) {
-            // Collect data on a background queue so the host app's main thread
-            // doesn't hitch while OSLogStore builds its enumerator (can take
-            // hundreds of ms). Metadata collection (UIKit) runs on main first.
+            // The widget waits a fixed, short time for this reply and silently
+            // creates the ticket with NO data at all when it is late — not just
+            // without console logs, but without environment data, custom data and
+            // tags too. So nothing here may block on slow collection: everything
+            // except the console log is read from memory and is instant, and the
+            // logs (OSLogStore, regularly slower than the widget will wait) are
+            // collected under a deadline and dropped when they miss it.
             GleapFeedback *feedback = [[GleapFeedback alloc] init];
             __weak typeof(self) weakSelf = self;
-            [feedback prepareDataAsyncWithCompletion:^{
+            [feedback prepareDataWithDeadline: kGleapCollectTicketDataDeadline completion:^{
                 [weakSelf sendMessageWithData: @{
                     @"name": @"collect-ticket-data",
                     @"data": @{


### PR DESCRIPTION
## Problem

App conversations arrive with a completely empty **Environment data** tab. Not partially empty — the whole block is missing, so the dashboard renders "no environment data" and a white screen.

The widget asks the host SDK for the ticket's data over the JS bridge and waits a fixed, short time for the reply ([`sendMessageWithResolver`](https://github.com/GleapSDK/Messenger-App/blob/main/src/Helper/CommunicationManager.ts)). When the reply is late it does **not** fall back to a partial payload — `getTicketData` resolves `{}` and the conversation is created with no environment data, no custom data, no form data, no tags and no logs. Nothing backfills it afterwards.

Since console logs moved to `OSLogStore`, our reply routinely misses that window:

- `collect-ticket-data` waits for `prepareDataAsyncWithCompletion`, which includes `getConsoleLogs()`.
- Building the `OSLogStore` enumerator alone takes hundreds of ms on a real device. `kGleapOSLogMaxWallClock` (0.2s) only starts counting *after* the enumerator exists, so it does not bound the expensive part.
- Android answers the same message synchronously from cached state (`GleapMainActivity.java`) and is unaffected — which is why this reads as an iOS-only bug.

## Fix

Everything except the console log is read from in-memory state and returns immediately, so the report is now assembled up front and only the logs are collected asynchronously, under a **0.4s deadline** — comfortably inside the widget's window.

- `prepareBackgroundData` is split into `collectConsoleLog` (the slow part, no `self.data` mutation) + `prepareInMemoryData` (everything else). Behaviour of `prepareData` / `prepareBackgroundData` is unchanged.
- `prepareDataAsyncWithCompletion` → `prepareDataWithDeadline:completion:`. Both completion paths run on the main queue, so `finished` and `self.data` stay serialised against the background collection.
- Logs that miss the deadline are dropped. Environment data no longer depends on them.

## Evidence

For the reporting project, iOS conversations carried environment data **100%** of the time through the week of 2026-04-19, then collapsed — currently ~6%. Android is ~99% across the same period.

## Verification

`xcodebuild -scheme Gleap -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**.

## Note

There is a companion fix in the messenger (`gleap/137095-collect-ticket-data-timeout`) that raises the app-mode budget. That one reaches app builds **already in the field**; this one keeps the reply fast so the budget is not consumed. Both are worth shipping.

No version bump here — left to the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)