### PR TITLE
fix(modal): tell the info card how much room it has

### DIFF
--- a/Gleap.podspec
+++ b/Gleap.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Gleap"
-  s.version      = "16.4.2"
+  s.version      = "16.4.3"
   s.summary      = "In-App Bug Reporting and Testing for Apps. Learn more at https://gleap.io"
   s.homepage     = "https://gleap.io"
   s.license      = { :type => 'Commercial', :file => 'LICENSE.md' }

--- a/Sources/ObjCSources/GleapMetaDataHelper.h
+++ b/Sources/ObjCSources/GleapMetaDataHelper.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#define SDK_VERSION @"16.4.2"
+#define SDK_VERSION @"16.4.3"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/ObjCSources/GleapModal.m
+++ b/Sources/ObjCSources/GleapModal.m
@@ -13,12 +13,15 @@
 // Redeclare as readwrite to match the public readonly in the header
 @property (nonatomic, strong, readwrite) NSLayoutConstraint *heightConstraint;
 @property (nonatomic, strong, readwrite) NSLayoutConstraint *maxWidthConstraint;
-// The web content sizes itself to the web view's frame and never overflows, so
-// a too-tall card can't scroll on its own. Instead size the web view to its full
-// content height and scroll it in this scroll view inside the capped container.
+// The web content scrolls its own body once it knows how much room it has (we
+// send that as `maxHeight`), so it normally reports a height that already fits
+// and this scroll view sits idle. It's the fallback for content that reports
+// more than the cap anyway — an older web bundle, or a card that can't shrink.
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) NSLayoutConstraint *containerHeightConstraint;
 @property (nonatomic, assign) CGFloat reportedContentHeight;
+@property (nonatomic, assign) CGFloat lastSentMaxHeight;
+@property (nonatomic, assign) BOOL webContentLoaded;
 @end
 
 @implementation GleapModal
@@ -104,7 +107,8 @@
     self.webView.layer.cornerRadius = 20.0;
     self.webView.layer.masksToBounds = YES;
     self.webView.scrollView.bounces = NO;
-    // Inner scroll off; the outer scroll view scrolls the full-height web view.
+    // Disables the main frame's scroll view only — the card's own scroll region
+    // still scrolls, and that's the one that should.
     self.webView.scrollView.scrollEnabled = NO;
     self.webView.scrollView.alwaysBounceHorizontal = NO;
     self.webView.scrollView.alwaysBounceVertical = NO;
@@ -193,12 +197,22 @@
         NSDictionary *data = body[@"data"];
         
         if ([name isEqualToString:@"modal-loaded"]) {
+            self.webContentLoaded = YES;
             NSDictionary *flowConfig = [GleapConfigHelper sharedInstance].config;
             NSString *primaryColor = flowConfig[@"color"] ?: @"#485BFF";
             NSString *backgroundColor = flowConfig[@"backgroundColor"] ?: @"#FFFFFF";
             NSMutableDictionary *payload = [[self.modalData objectForKey:@"config"] mutableCopy];
             payload[@"primaryColor"] = primaryColor;
             payload[@"backgroundColor"] = backgroundColor;
+
+            // Tell the card how much room it has, so it scrolls its own content
+            // instead of reporting a height we'd have to clip or scroll again.
+            CGFloat maxHeight = [self maxContentHeight];
+            if (maxHeight > 0) {
+                payload[@"maxHeight"] = @(floor(maxHeight));
+                self.lastSentMaxHeight = maxHeight;
+            }
+
             [self sendMessageWithData:@{@"name":@"modal-data",@"data":payload}];
         }
         else if ([name isEqualToString:@"modal-height"]) {
@@ -347,14 +361,40 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
     if (self.reportedContentHeight > 0) {
         self.containerHeightConstraint.constant = [self cappedContainerHeight];
     }
+
+    // Rotating changes how much room the card has, so it needs to re-lay out
+    // and report a height that fits the new orientation.
+    [self sendMaxHeightIfChanged];
 }
 
-// Full content height capped to a screen fraction (smaller in landscape).
-- (CGFloat)cappedContainerHeight {
+// How tall the card may be: a fraction of the screen, smaller in landscape.
+- (CGFloat)maxContentHeight {
     CGFloat screenH = CGRectGetHeight(self.bounds);
     BOOL isLandscape = CGRectGetWidth(self.bounds) > screenH;
     CGFloat heightMultiplier = isLandscape ? 0.8 : 0.9;
-    return MIN(self.reportedContentHeight, screenH * heightMultiplier);
+    return screenH * heightMultiplier;
+}
+
+// Reported content height, capped to the room the card has.
+- (CGFloat)cappedContainerHeight {
+    return MIN(self.reportedContentHeight, [self maxContentHeight]);
+}
+
+- (void)sendMaxHeightIfChanged {
+    if (!self.webContentLoaded) {
+        return;
+    }
+
+    CGFloat maxHeight = [self maxContentHeight];
+    if (maxHeight <= 0 || fabs(maxHeight - self.lastSentMaxHeight) < 1.0) {
+        return;
+    }
+    self.lastSentMaxHeight = maxHeight;
+
+    [self sendMessageWithData:@{
+        @"name": @"modal-max-height",
+        @"data": @{@"maxHeight": @(floor(maxHeight))}
+    }];
 }
 
 @end


### PR DESCRIPTION
Fixes #30. Pairs with GleapSDK/BannerApp#20 — **both are needed**; see "Rollout" below.

### Why #25 wasn't enough

#25 correctly observed that the web content "always sizes itself to the web view's frame and never overflows," and wrapped the web view in a `UIScrollView` so tall cards could scroll. But the reason it never overflowed is that the modal content clamps *itself* at a hardcoded 600 px and scrolls its own text block internally.

So on a landscape card — capped to 80% of the screen — the content's inner scroller ended up nested inside the new native one. That's the two scrolling sections @slangeder reported. The portrait flicker is the same defect from the other side: the content measures `.gleap-modal` after we've sized the web view to whatever it last reported, so its answer feeds back into itself, resampled every 100 ms against our 0.25 s height animation.

Android doesn't hit either, because it sizes its WebView to the *visible* window — the content there only ever has one place to scroll.

### The change

The card can size itself correctly once it knows its bounds, so send them:

- `maxHeight` goes out with `modal-data`, and again as `modal-max-height` whenever rotation changes the cap.
- The card then reports a height that already fits, so the container and the web view come out the same size and the scroll view from #25 sits idle.
- Kept that scroll view rather than reverting #25: it's the fallback for content that reports more than the cap anyway — an older cached web bundle, or a card that can't shrink.
- `cappedContainerHeight` split into `maxContentHeight` (the cap itself) and the min against the reported height, since both callers now need the cap on its own.

Version bumped to 16.4.3. Note the wrappers (Flutter, Capacitor, ReactNative) share this version per `CLAUDE.md` and will drift until separately bumped.

### Verified

Message flow and container capping exercised against the real host contract, with the BannerApp change in place:

| case | reported | native scroll overflow |
|---|---|---|
| portrait, cap 600 | 600 | **0** |
| landscape, cap 300 | 300 | **0** |
| tiny, cap 180 | 180 | **0** |
| short card, cap 600 | 194 (natural) | 0 |

Zero height messages while idle — the oscillation behind the flicker is gone. `GleapModal.m` compiles clean with `-Wall` against the iOS simulator SDK.

### Rollout

GleapSDK/BannerApp#20 is hosted, so deploying it fixes the flicker and portrait on 16.4.2 **without an SDK release**. Landscape with very tall content still double-scrolls there (measured: native overflow 300 *and* inner overflow 284) — the content can't detect that case, because on 16.4.2 the web view is sized to the full content and only the container is capped, which is invisible from inside the frame. That case needs this release.

Deploy BannerApp first: this PR's `maxHeight` is inert without it.

@slangeder — happy to have you verify against your app once both are out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)